### PR TITLE
apply Halborn comments

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -57,6 +57,12 @@ impl ExitReason {
 	pub const fn is_fatal(&self) -> bool {
 		matches!(self, Self::Fatal(_))
 	}
+
+	/// Whether the step limit has been reached.
+	#[must_use]
+	pub const fn is_step_limit(&self) -> bool {
+		matches!(self, Self::StepLimitReached)
+	}
 }
 
 /// Exit succeed reason.

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -29,6 +29,7 @@ pub enum ExitReason {
 	Revert(ExitRevert),
 	/// Machine encountered an error that is not supposed to be normal EVM
 	/// errors, such as requiring too much memory to execute.
+
 	Fatal(ExitFatal),
 }
 

--- a/core/src/eval/arithmetic.rs
+++ b/core/src/eval/arithmetic.rs
@@ -2,6 +2,7 @@ use core::ops::Rem;
 use core::convert::TryInto;
 use crate::{utils::I256, U256, U512};
 
+/// Integer division operation
 pub fn div(op1: U256, op2: U256) -> U256 {
 	if op2 == U256::zero() {
 		U256::zero()
@@ -10,6 +11,7 @@ pub fn div(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Signed integer division operation (truncated)
 pub fn sdiv(op1: U256, op2: U256) -> U256 {
 	let op1: I256 = op1.into();
 	let op2: I256 = op2.into();
@@ -17,6 +19,7 @@ pub fn sdiv(op1: U256, op2: U256) -> U256 {
 	ret.into()
 }
 
+/// Modulo remainder operation
 pub fn rem(op1: U256, op2: U256) -> U256 {
 	if op2 == U256::zero() {
 		U256::zero()
@@ -25,6 +28,7 @@ pub fn rem(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Signed modulo remainder operation
 pub fn srem(op1: U256, op2: U256) -> U256 {
 	if op2 == U256::zero() {
 		U256::zero()
@@ -36,6 +40,7 @@ pub fn srem(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Modulo addition operation
 pub fn addmod(op1: U256, op2: U256, op3: U256) -> U256 {
 	let op1: U512 = op1.into();
 	let op2: U512 = op2.into();
@@ -49,6 +54,7 @@ pub fn addmod(op1: U256, op2: U256, op3: U256) -> U256 {
 	}
 }
 
+/// Modulo multiplication operation
 pub fn mulmod(op1: U256, op2: U256, op3: U256) -> U256 {
 	let op1: U512 = op1.into();
 	let op2: U512 = op2.into();
@@ -62,6 +68,7 @@ pub fn mulmod(op1: U256, op2: U256, op3: U256) -> U256 {
 	}
 }
 
+/// Exponential operation
 pub fn exp(op1: U256, op2: U256) -> U256 {
 	let mut op1 = op1;
 	let mut op2 = op2;
@@ -78,6 +85,7 @@ pub fn exp(op1: U256, op2: U256) -> U256 {
 	r
 }
 
+/// Extend length of two’s complement signed integer
 pub fn signextend(op1: U256, op2: U256) -> U256 {
 	if op1 >= U256::from(32) {
 		op2

--- a/core/src/eval/arithmetic.rs
+++ b/core/src/eval/arithmetic.rs
@@ -79,7 +79,7 @@ pub fn exp(op1: U256, op2: U256) -> U256 {
 }
 
 pub fn signextend(op1: U256, op2: U256) -> U256 {
-	if op1 > U256::from(32) {
+	if op1 >= U256::from(32) {
 		op2
 	} else {
 		let mut ret = U256::zero();

--- a/core/src/eval/arithmetic.rs
+++ b/core/src/eval/arithmetic.rs
@@ -82,20 +82,17 @@ pub fn signextend(op1: U256, op2: U256) -> U256 {
 	if op1 >= U256::from(32) {
 		op2
 	} else {
-		let mut ret = U256::zero();
-		let len: usize = op1.as_usize();
-		let t: usize = 8 * (len + 1) - 1;
-		let t_bit_mask = U256::one() << t;
-		let t_value = (op2 & t_bit_mask) >> t;
-		for i in 0..256 {
-			let bit_mask = U256::one() << i;
-			let i_value = (op2 & bit_mask) >> i;
-			if i <= t {
-				ret = ret.overflowing_add(i_value << i).0;
-			} else {
-				ret = ret.overflowing_add(t_value << i).0;
-			}
+		let byte_index = op1.as_usize();
+		let bit_index = 8 * byte_index + 7;
+
+		if op2.bit(bit_index) {
+			// Sign bit is 1 → extend with 1s
+			let mask = U256::MAX << (bit_index + 1);
+			op2 | mask
+		} else {
+			// Sign bit is 0 → zero out upper bits
+			let mask = (U256::one() << (bit_index + 1)) - 1;
+			op2 & mask
 		}
-		ret
 	}
 }

--- a/core/src/eval/bitwise.rs
+++ b/core/src/eval/bitwise.rs
@@ -57,8 +57,7 @@ pub fn shl(shift: U256, value: U256) -> U256 {
 	if value == U256::zero() || shift >= U256::from(256) {
 		U256::zero()
 	} else {
-		let shift: u64 = shift.as_u64();
-		value << shift as usize
+		value << shift.as_usize()
 	}
 }
 
@@ -66,8 +65,7 @@ pub fn shr(shift: U256, value: U256) -> U256 {
 	if value == U256::zero() || shift >= U256::from(256) {
 		U256::zero()
 	} else {
-		let shift: u64 = shift.as_u64();
-		value >> shift as usize
+		value >> shift.as_usize()
 	}
 }
 
@@ -83,12 +81,11 @@ pub fn sar(shift: U256, value: U256) -> U256 {
 			Sign::Minus => I256(Sign::Minus, U256::one()).into(),
 		}
 	} else {
-		let shift: u64 = shift.as_u64();
 
 		match value.0 {
-			Sign::Plus | Sign::NoSign => value.1 >> shift as usize,
+			Sign::Plus | Sign::NoSign => value.1 >> shift.as_usize(),
 			Sign::Minus => {
-				let shifted = ((value.1.overflowing_sub(U256::one()).0) >> shift as usize)
+				let shifted = ((value.1.overflowing_sub(U256::one()).0) >> shift.as_usize())
 					.overflowing_add(U256::one()).0;
 				I256(Sign::Minus, shifted).into()
 			}

--- a/core/src/eval/bitwise.rs
+++ b/core/src/eval/bitwise.rs
@@ -38,19 +38,14 @@ pub fn not(op1: U256) -> U256 {
 }
 
 pub fn byte(op1: U256, op2: U256) -> U256 {
-	let mut ret = U256::zero();
-
-	for i in 0..256 {
-		if i < 8 && op1 < 32.into() {
-			let o: usize = op1.as_usize();
-			let t = 255 - (7 - i + 8 * o);
-			let bit_mask = U256::one() << t;
-			let value = (op2 & bit_mask) >> t;
-			ret = ret.overflowing_add(value << i).0;
-		}
+	let i = op1.as_usize();
+	if i >= 32 {
+		U256::zero()
+	} else {
+		let mut buf = [0u8; 32];
+		op2.to_big_endian(&mut buf);
+		U256::from(buf[i])
 	}
-
-	ret
 }
 
 pub fn shl(shift: U256, value: U256) -> U256 {

--- a/core/src/eval/bitwise.rs
+++ b/core/src/eval/bitwise.rs
@@ -3,6 +3,7 @@
 use crate::U256;
 use crate::utils::{Sign, I256};
 
+/// Signed less-than comparison
 pub fn slt(op1: U256, op2: U256) -> U256 {
 	let op1: I256 = op1.into();
 	let op2: I256 = op2.into();
@@ -14,6 +15,7 @@ pub fn slt(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Signed greater-than comparison
 pub fn sgt(op1: U256, op2: U256) -> U256 {
 	let op1: I256 = op1.into();
 	let op2: I256 = op2.into();
@@ -25,6 +27,7 @@ pub fn sgt(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Is-zero comparison
 pub fn iszero(op1: U256) -> U256 {
 	if op1 == U256::zero() {
 		U256::one()
@@ -33,10 +36,12 @@ pub fn iszero(op1: U256) -> U256 {
 	}
 }
 
+/// Bitwise NOT operation
 pub fn not(op1: U256) -> U256 {
 	!op1
 }
 
+/// Retrieve single byte from word
 pub fn byte(op1: U256, op2: U256) -> U256 {
 	let i = op1.as_usize();
 	if i >= 32 {
@@ -48,6 +53,7 @@ pub fn byte(op1: U256, op2: U256) -> U256 {
 	}
 }
 
+/// Left shift operation
 pub fn shl(shift: U256, value: U256) -> U256 {
 	if value == U256::zero() || shift >= U256::from(256) {
 		U256::zero()
@@ -56,6 +62,7 @@ pub fn shl(shift: U256, value: U256) -> U256 {
 	}
 }
 
+/// Right shift operation
 pub fn shr(shift: U256, value: U256) -> U256 {
 	if value == U256::zero() || shift >= U256::from(256) {
 		U256::zero()
@@ -64,6 +71,7 @@ pub fn shr(shift: U256, value: U256) -> U256 {
 	}
 }
 
+/// Arithmetic (signed) right shift operation
 pub fn sar(shift: U256, value: U256) -> U256 {
 	let value = I256::from(value);
 

--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -1,8 +1,3 @@
-macro_rules! trace_op {
-//	($($arg:tt)*) => (log::trace!(target: "evm", "OpCode {}", format_args!($($arg)*)));
-        ($($arg:tt)*) => ();
-}
-
 macro_rules! try_or_fail {
 	( $e:expr ) => {
 		match $e {
@@ -62,7 +57,6 @@ macro_rules! op1_u256_fn {
 			pop_u256!($machine, op1);
 			let ret = $op(op1);
 			push_u256!($machine, ret);
-			trace_op!("{} {}: {}", stringify!($op), op1, ret);
 
 			Control::Continue(1)
 		}
@@ -79,7 +73,6 @@ macro_rules! op2_u256_bool_ref {
 			} else {
 				U256::zero()
 			});
-			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -92,7 +85,6 @@ macro_rules! op2_u256 {
 			pop_u256!($machine, op1, op2);
 			let ret = op1.$op(op2);
 			push_u256!($machine, ret);
-			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -105,7 +97,6 @@ macro_rules! op2_u256_tuple {
 			pop_u256!($machine, op1, op2);
 			let (ret, ..) = op1.$op(op2);
 			push_u256!($machine, ret);
-			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -118,7 +109,6 @@ macro_rules! op2_u256_fn {
 			pop_u256!($machine, op1, op2);
 			let ret = $op(op1, op2);
 			push_u256!($machine, ret);
-			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -131,7 +121,6 @@ macro_rules! op3_u256_fn {
 			pop_u256!($machine, op1, op2, op3);
 			let ret = $op(op1, op2, op3);
 			push_u256!($machine, ret);
-			trace_op!("{} {}, {}, {}: {}", stringify!($op), op1, op2, op3, ret);
 
 			Control::Continue(1)
 		}

--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -29,6 +29,7 @@ macro_rules! pop_u256 {
 	);
 }
 
+/// push H256 to stack
 macro_rules! push {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
@@ -40,6 +41,7 @@ macro_rules! push {
 	)
 }
 
+/// push U256 to stack
 macro_rules! push_u256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
@@ -51,6 +53,7 @@ macro_rules! push_u256 {
 	)
 }
 
+/// call fn(v)
 macro_rules! op1_u256_fn {
 	( $machine:expr, $op:path ) => (
 		{
@@ -63,6 +66,7 @@ macro_rules! op1_u256_fn {
 	)
 }
 
+/// compare v1, v2
 macro_rules! op2_u256_bool_ref {
 	( $machine:expr, $op:ident ) => (
 		{
@@ -79,6 +83,7 @@ macro_rules! op2_u256_bool_ref {
 	)
 }
 
+/// v1.fn(v2)
 macro_rules! op2_u256 {
 	( $machine:expr, $op:ident ) => (
 		{
@@ -91,6 +96,7 @@ macro_rules! op2_u256 {
 	)
 }
 
+/// (a, b) = v1.fn(v2),
 macro_rules! op2_u256_tuple {
 	( $machine:expr, $op:ident ) => (
 		{
@@ -103,6 +109,7 @@ macro_rules! op2_u256_tuple {
 	)
 }
 
+/// fn(v1, v2)
 macro_rules! op2_u256_fn {
 	( $machine:expr, $op:path ) => (
 		{
@@ -115,6 +122,7 @@ macro_rules! op2_u256_fn {
 	)
 }
 
+/// fn(v1, v2, v3)
 macro_rules! op3_u256_fn {
 	( $machine:expr, $op:path ) => (
 		{
@@ -127,6 +135,7 @@ macro_rules! op3_u256_fn {
 	)
 }
 
+/// cast U256 to usize
 macro_rules! as_usize_or_fail {
 	( $v:expr ) => {
 		{

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -1,3 +1,5 @@
+/// implementation of the non-external opcodes
+
 #[macro_use]
 mod macros;
 mod arithmetic;
@@ -455,6 +457,7 @@ fn eval_external(_state: &mut Machine, opcode: Opcode, _position: usize) -> Cont
 	Control::Trap(opcode)
 }
 
+/// process non-external opcodes
 #[allow(clippy::too_many_lines)]
 pub fn eval(state: &mut Machine, opcode: Opcode, position: usize) -> Control {
 	static TABLE: [fn(state: &mut Machine, opcode: Opcode, position: usize) -> Control; 256] = {

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use crate::{ExitError, H256, U256};
 
+/// serialization/deserialization of the Stack
 #[cfg(feature = "with-serde")]
 mod serde_vec_u256 {
 	use serde::{Serializer, Deserializer, de};

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -1,3 +1,4 @@
+/// check the value
 macro_rules! try_or_fail {
 	( $e:expr ) => {
 		match $e {
@@ -7,6 +8,7 @@ macro_rules! try_or_fail {
 	}
 }
 
+// try to pop a H256 from stack
 macro_rules! pop {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
@@ -18,6 +20,8 @@ macro_rules! pop {
 	);
 }
 
+
+// try to pop a U256 from stack
 macro_rules! pop_u256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
@@ -29,6 +33,7 @@ macro_rules! pop_u256 {
 	);
 }
 
+/// try to push H256 to the stack
 macro_rules! push {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
@@ -40,6 +45,7 @@ macro_rules! push {
 	)
 }
 
+/// try to push U256 to the stack
 macro_rules! push_u256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
@@ -51,6 +57,7 @@ macro_rules! push_u256 {
 	)
 }
 
+/// cast to usize
 macro_rules! as_usize_or_fail {
 	( $v:expr ) => {
 		{

--- a/runtime/src/eval/mod.rs
+++ b/runtime/src/eval/mod.rs
@@ -5,7 +5,7 @@ mod system;
 pub use system::{save_return_value, save_created_address};
 use crate::{Handler, Runtime, ExitReason, CallScheme, Opcode};
 
-/// ...
+/// continue the execution / spawn next frame / exit to previous frame
 pub enum Control<H: Handler> {
 	/// ...
 	Continue,
@@ -17,6 +17,7 @@ pub enum Control<H: Handler> {
 	Exit(ExitReason)
 }
 
+/// handler for unknown opcode
 fn handle_other<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H) -> Control<H> {
 	match handler.other(
 		opcode,
@@ -27,6 +28,7 @@ fn handle_other<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H
 	}
 }
 
+/// process `external` opcodes
 pub fn eval<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H) -> Control<H> {
 	match opcode {
 		Opcode::SHA3 => system::sha3(state, handler),

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use crate::{Runtime, ExitError, Handler, Capture, Transfer, ExitReason, CreateScheme, CallScheme, Context, ExitSucceed, ExitFatal, H160, H256, U256};
 use super::Control;
 
-
+/// Compute Keccak-256 hash
 pub fn sha3<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, from, len);
 	let from = as_usize_or_fail!(from);
@@ -22,12 +22,15 @@ pub fn sha3<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+
+// Get the chain ID
 pub fn chainid<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.chain_id());
 
 	Control::Continue
 }
 
+/// Get address of currently executing account
 pub fn address<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let ret = H256::from(runtime.context.address);
 	push!(runtime, ret);
@@ -35,6 +38,7 @@ pub fn address<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	Control::Continue
 }
 
+/// Get balance of the given account
 pub fn balance<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop!(runtime, address);
 	push_u256!(runtime, handler.balance(address.into()));
@@ -42,18 +46,21 @@ pub fn balance<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Get balance of currently executing account
 pub fn selfbalance<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.balance(runtime.context.address));
 
 	Control::Continue
 }
 
+/// Get the base fee
 pub fn basefee<H: Handler>(runtime: &mut Runtime, _handler: &H) -> Control<H> {
 	push_u256!(runtime, U256::zero());
 
 	Control::Continue
 }
 
+/// Get execution origination address
 pub fn origin<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let ret = H256::from(handler.origin());
 	push!(runtime, ret);
@@ -61,6 +68,7 @@ pub fn origin<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Get caller address
 pub fn caller<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let ret = H256::from(runtime.context.caller);
 	push!(runtime, ret);
@@ -68,6 +76,7 @@ pub fn caller<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	Control::Continue
 }
 
+/// Get deposited value by the instruction/transaction responsible for this execution
 pub fn callvalue<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let mut ret = H256::default();
 	runtime.context.apparent_value.to_big_endian(&mut ret[..]);
@@ -76,6 +85,7 @@ pub fn callvalue<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	Control::Continue
 }
 
+/// Get price of gas in current environment
 pub fn gasprice<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let mut ret = H256::default();
 	handler.gas_price().to_big_endian(&mut ret[..]);
@@ -84,6 +94,7 @@ pub fn gasprice<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Get size of an account’s code
 pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop!(runtime, address);
 	push_u256!(runtime, handler.code_size(address.into()));
@@ -91,6 +102,7 @@ pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H>
 	Control::Continue
 }
 
+/// Get hash of an account’s code
 pub fn extcodehash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop!(runtime, address);
 	push!(runtime, handler.code_hash(address.into()));
@@ -98,6 +110,7 @@ pub fn extcodehash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H>
 	Control::Continue
 }
 
+/// Copy an account’s code to memory
 pub fn extcodecopy<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop!(runtime, address);
 	pop_u256!(runtime, memory_offset, code_offset, len);
@@ -120,6 +133,7 @@ pub fn extcodecopy<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H>
 	Control::Continue
 }
 
+/// Get size of output data from the previous call from the current environment
 pub fn returndatasize<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let size = U256::from(runtime.return_data_buffer.len());
 	push_u256!(runtime, size);
@@ -127,6 +141,7 @@ pub fn returndatasize<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	Control::Continue
 }
 
+/// Copy output data from the previous call to memory
 pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	pop_u256!(runtime, memory_offset, data_offset, len);
 
@@ -148,6 +163,7 @@ pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	}
 }
 
+/// Get the hash of one of the 256 most recent complete blocks
 pub fn blockhash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, number);
 	push!(runtime, handler.block_hash(number));
@@ -155,31 +171,37 @@ pub fn blockhash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Get the block’s beneficiary address
 pub fn coinbase<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push!(runtime, handler.block_coinbase().into());
 	Control::Continue
 }
 
+/// Get the block’s timestamp
 pub fn timestamp<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.block_timestamp());
 	Control::Continue
 }
 
+/// Get the block’s number
 pub fn number<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.block_number());
 	Control::Continue
 }
 
+/// Get the block’s difficulty (PREVRANDAO)
 pub fn difficulty<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.block_difficulty());
 	Control::Continue
 }
 
+/// Get the block’s gas limit
 pub fn gaslimit<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.block_gas_limit());
 	Control::Continue
 }
 
+/// Load word from storage
 pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, index);
 	let value = handler.storage(runtime.context.address, index);
@@ -188,6 +210,7 @@ pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Save word to storage
 pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop_u256!(runtime, index, value);
 
@@ -197,6 +220,7 @@ pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> 
 	}
 }
 
+/// Load word from transient storage
 pub fn tload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, index);
 	let value = handler.transient_storage(runtime.context.address, index);
@@ -205,6 +229,7 @@ pub fn tload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
+/// Save word to transient storage
 pub fn tstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop_u256!(runtime, index, value);
 
@@ -214,12 +239,16 @@ pub fn tstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> 
 	}
 }
 
+/// Get the amount of available gas, including the corresponding reduction for the cost of
+/// this instruction
 pub fn gas<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.gas_left());
 
 	Control::Continue
 }
 
+
+/// Append log record
 pub fn log<H: Handler>(runtime: &mut Runtime, n: u8, handler: &mut H) -> Control<H> {
 	pop_u256!(runtime, offset, len);
 	let offset = as_usize_or_fail!(offset);
@@ -246,6 +275,7 @@ pub fn log<H: Handler>(runtime: &mut Runtime, n: u8, handler: &mut H) -> Control
 	}
 }
 
+// Halt execution and register account for later deletion or send all Ether to address (post-Cancun)
 pub fn suicide<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop!(runtime, target);
 
@@ -257,6 +287,7 @@ pub fn suicide<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H>
 	Control::Exit(ExitSucceed::Suicided.into())
 }
 
+/// Create a new account with associated code
 pub fn create<H: Handler>(
 	runtime: &mut Runtime,
 	is_create2: bool,
@@ -302,6 +333,7 @@ pub fn create<H: Handler>(
 	}
 }
 
+/// Message-call into an account
 pub fn call<'config, H: Handler>(
 	runtime: &mut Runtime,
 	scheme: CallScheme,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,47 +207,6 @@ pub struct Config {
 pub const CONFIG: Config = Config::istanbul();
 
 impl Config {
-	/// Frontier hard fork configuration.
-	pub const fn frontier() -> Config {
-		Config {
-			gas_ext_code: 20,
-			gas_ext_code_hash: 20,
-			gas_balance: 20,
-			gas_sload: 50,
-			gas_sstore_set: 20000,
-			gas_sstore_reset: 5000,
-			refund_sstore_clears: 15000,
-			gas_suicide: 0,
-			gas_suicide_new_account: 0,
-			gas_call: 40,
-			gas_expbyte: 10,
-			gas_transaction_create: 21000,
-			gas_transaction_call: 21000,
-			gas_transaction_zero_data: 4,
-			gas_transaction_non_zero_data: 68,
-			sstore_gas_metering: false,
-			sstore_revert_under_stipend: false,
-			err_on_call_with_more_gas: true,
-			empty_considered_exists: true,
-			create_increase_nonce: false,
-			call_l64_after_gas: false,
-			stack_limit: 1024,
-			memory_limit: usize::max_value(),
-			call_stack_limit: 1024,
-			create_contract_limit: None,
-			call_stipend: 2300,
-			has_delegate_call: false,
-			has_create2: false,
-			has_revert: false,
-			has_return_data: false,
-			has_bitwise_shifting: false,
-			has_chain_id: false,
-			has_self_balance: false,
-			has_ext_code_hash: false,
-			estimate: false,
-		}
-	}
-
 	/// Istanbul hard fork configuration.
 	pub const fn istanbul() -> Config {
 		Config {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,7 +18,10 @@ mod eval;
 mod interrupt;
 mod handler;
 
-pub use evm_core::*;
+pub use evm_core::{
+	Machine, Transfer, ExitReason, Context, Capture, Stack, ExitError, CreateScheme, CallScheme,
+	ExitSucceed, ExitFatal, H160, H256, U256, Opcode,
+};
 
 pub use crate::interrupt::{Resolve, ResolveCall, ResolveCreate};
 pub use crate::handler::Handler;


### PR DESCRIPTION
- HAL-01 - Memory resize does not enforce memory limit boundary **- fixed**

- HAL-02 - Memory usage update omitted after buffer resize in set **- fixed**

- HAL-03 - Glob re-export from evm_core combined with aliased re-export causes compilation error **- fixed**

- HAL-04 - Signextend function allows invalid byte index **- fixed**

- HAL-05 - Unnecessary imports **- fixed**

- HAL-06 - Missing Cancun opcodes limits compatibility with latest EVM contracts **- _skipped_**

> Rome- evm doesn't support the transaction type 0x03.  
> Unknown opcodes are processed by method "other()" of Handler trait: 
> https://github.com/rome-protocol/evm/blob/fff75db8dd886400b8c44377e40045ebfb887502/runtime/src/eval/mod.rs#L70
> This trait is impemented in the Rome-evm contract. Handler.other() raises an error if unknown opcode appears:
> https://github.com/rome-protocol/rome-evm-private/blob/e127dca5266ad907da3dec8a020299e2bc378bdc/program/src/state/handler.rs#L310


- HAL-07 - Redundant trace_op! Calls Despite Macro Being Disabled **- fixed**

- HAL-08 - Runtime uses fixed configuration and exposes unused alternative profile **- fixed**

- HAL-09 - Redundant type conversions **- fixed**

- HAL-10 - ExitReason lacks method to identify step limit exhaustion **- fixed**

- HAL-11 - Inefficient implementations functions introduce unnecessary complexity **- fixed**

- HAL-12 - Lack of consistent documentation across the codebase **- fixed**

