### PR TITLE
Add CLAUDE.md for Claude Code onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rome Protocol's fork of SputnikVM — a portable, stateless Ethereum Virtual Machine (EVM) written in Rust. The EVM is designed to be embedded into other systems (the caller provides state via a `Handler` trait).
+
+## Build Commands
+
+```bash
+cargo build --release --all    # Build all crates
+cargo test                     # Run all tests
+cargo clippy --all-targets --all-features  # Lint
+cargo fmt                      # Format
+cargo fmt -- --check           # Check formatting without modifying
+```
+
+## Lint Configuration
+
+The root `src/lib.rs` enforces strict linting:
+- `#![deny(warnings)]`
+- `#![forbid(unsafe_code, missing_docs, unused_variables, unused_imports)]`
+- `#![deny(clippy::all, clippy::pedantic, clippy::nursery)]`
+
+All new public items require doc comments. Unsafe code is forbidden.
+
+## Architecture
+
+Three crates in a layered architecture:
+
+**evm** (root) — Top-level re-export crate. Re-exports everything from `evm-core` and `evm-runtime`.
+
+**evm-core** (`core/`) — Low-level bytecode interpreter. No blockchain state awareness.
+- `Machine` struct: stack, memory, program counter, bytecode execution
+- `Opcode`: all EVM opcode definitions
+- `ExitReason`: execution termination types (Succeed, Error, Revert, Fatal, StepLimitReached)
+- `eval/` subdirectory: opcode evaluation split into `arithmetic.rs`, `bitwise.rs`, `misc.rs`
+- Primitive types (`H160`, `H256`, `U256`) defined via `fixed-hash` and `uint` macros in `primitive_types.rs`
+
+**evm-runtime** (`runtime/`) — Execution interface connecting the machine to external state.
+- `Runtime` struct: wraps `Machine` with execution context
+- `Handler` trait: the key integration point — implementors provide account/block queries, storage mutations, and CALL/CREATE handling
+- `Config` struct: hardfork feature flags (default: Istanbul)
+- Interrupt model: `Capture<E, T>` enum with `Exit` (done) or `Trap` (needs external input for CALL/CREATE)
+
+### Execution Flow
+
+1. Caller creates `Runtime` with bytecode, context, and `Config`
+2. Runtime steps through opcodes via `Machine`
+3. On CALL/CREATE, runtime returns `Capture::Trap(Resolve::Call/Create(...))`
+4. Caller resolves the interrupt (executes sub-call, updates state)
+5. Feeds result back into the `Resolve` handle; execution resumes
+
+## Feature Flags
+
+- `std` (default): standard library support
+- `with-serde`: serde serialization
+- `with-codec`: parity-scale-codec support
+- All crates support `no_std` (with `alloc`)
+- `borsh` serialization is always enabled for Machine/Runtime state checkpointing
+
+## Rome Protocol Modifications
+
+Key changes from upstream SputnikVM (visible in recent PRs):
+- SELFDESTRUCT opcode disabled (PR #14)
+- `Handler::other()` returns `ExitFatal` instead of `ExitError` (PR #13)
+- Halborn security audit fixes (PR #12)
+- SPL-related modifications including `TransferProhibited` error variant (PR #9)
+- Removed unused backend/gasometer crates (PR #11)


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md with build/test/lint commands, strict lint rules, three-crate architecture overview, execution flow, feature flags, and Rome Protocol-specific modifications
- Helps future Claude Code instances be productive immediately in this repo

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm build commands are accurate: `cargo build --release --all`, `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)