### PR TITLE
chore: add agent readiness — CLAUDE.md sections + templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Report a bug
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+<!-- devnet / testnet / local -->
+
+## Logs / Error Messages

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Propose a new feature
+labels: enhancement
+---
+
+## Summary
+
+## Motivation
+
+## Proposed Solution
+
+## SPEC Reference
+<!-- If a SPEC exists: SPEC-{name}.md -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- What and why -->
+
+## SPEC Reference
+<!-- SPEC-{name}.md if applicable -->
+
+## Changes
+<!-- Key changes -->
+
+## Test Plan
+<!-- What was tested, how to verify -->
+
+## Cross-Repo Impact
+<!-- Which other repos are affected by this change -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,29 @@ Key changes from upstream SputnikVM (visible in recent PRs):
 - Halborn security audit fixes (PR #12)
 - SPL-related modifications including `TransferProhibited` error variant (PR #9)
 - Removed unused backend/gasometer crates (PR #11)
+
+## Agent Execution Guide
+
+- This is a SputnikVM fork. Changes are rare and high-impact.
+- Every opcode change affects all downstream repos (rome-evm-private, rome-sdk, rome-apps).
+- After any change, run `cargo test` here, then verify `rome-evm-private` builds against the local checkout (`../evm` path dependency).
+- The SELFDESTRUCT opcode is disabled — do not re-enable.
+- Handler trait modifications affect all EVM execution paths.
+
+## Change Impact Map
+
+| If you change... | Also check/update... |
+|-----------------|---------------------|
+| Any opcode implementation | `rome-evm-private/` (entrypoint macro, both program/ and emulator/) |
+| Handler trait | `rome-evm-private/` (implements Handler) |
+| Gas calculations | `rome-evm-private/` gasometer, `tests/` opcode suite |
+| evm-core (stack, memory) | All downstream: rome-evm-private, rome-sdk, rome-apps, tests |
+
+## Test Selection Guide
+
+| What Changed | Tests to Run |
+|-------------|-------------|
+| Any opcode | `cargo test` here + `cd ../rome-evm-private && cargo test` + `tests/` opcode suite |
+| Handler trait | `cargo test` + full rome-evm-private test suite |
+| Gas logic | `cargo test` + `tests/` opcode suite |
+| Core (stack/memory) | `cargo test` + everything downstream |


### PR DESCRIPTION
## Summary
- Add Agent Execution Guide, Change Impact Map, and Test Selection Guide to CLAUDE.md
- Add PR template and issue templates (bug report, feature request)
- Part of Session 2: Per-Repo Agent Readiness (SPEC-session-2-repo-readiness.md)

## SPEC Reference
SPEC-session-2-repo-readiness.md

## Changes
- **CLAUDE.md**: 3 new sections for agent guidance (execution guide, change impact map, test selection)
- **`.github/pull_request_template.md`**: Standardized PR template
- **`.github/ISSUE_TEMPLATE/`**: Bug report and feature request templates

## Test Plan
- Verify agent reads and follows Agent Execution Guide in a Claude Code session
- Verify templates render correctly on GitHub

## Cross-Repo Impact
None — documentation and templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)