### PR TITLE
ci: cancel stale runs on same-branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   RUSTFLAGS: "-Aunexpected_cfgs"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a branch-scoped `concurrency` block to `.github/workflows/ci.yml` so rapid pushes to the same ref cancel in-flight runs. Only same-branch reruns are cancelled — pushes to other branches never affect each other.

## Why
From the cross-repo CI audit ([rome-ops#45](https://github.com/rome-protocol/rome-ops/issues/45)): no concurrency cancellation means rapid pushes pile up runs. This is a pure cargo build/test workflow with no shared external state, so cancellation is safe.

## Test plan
- [ ] Push this branch — a single run starts.
- [ ] Push an empty commit on this branch — the previous run is cancelled and a new one starts.

Related: [rome-ops#45](https://github.com/rome-protocol/rome-ops/issues/45).

🤖 _This response was generated by Claude Code._