### PR TITLE
chore: drop unused sha3 dep (supersedes #24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 log = { version = "0.4", default-features = false }
 evm-core = { version = "0.18", path = "core", default-features = false, features = ["with-serde"] }
 evm-runtime = { version = "0.18", path = "runtime", default-features = false }
-sha3 = { version = "0.8", default-features = false }
 rlp = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
@@ -22,4 +21,4 @@ codec = { package = "parity-scale-codec", version = "1.3", default-features = fa
 default = ["std"]
 with-codec = ["codec", "evm-core/with-codec", "evm-runtime/with-codec"]
 with-serde = ["serde", "serde_bytes", "evm-core/with-serde", "evm-runtime/with-serde"]
-std = ["evm-core/std", "evm-runtime/std", "sha3/std", "serde/std", "codec/std", "log/std"]
+std = ["evm-core/std", "evm-runtime/std", "serde/std", "codec/std", "log/std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.18", path = "../core", default-features = false }
-sha3 = { version = "0.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
@@ -20,4 +19,4 @@ borsh = { version = "1.5.3", features = ["derive", "unstable__schema"] }
 default = ["std"]
 with-codec = ["codec"]
 with-serde = ["serde", "serde_bytes"]
-std = ["evm-core/std", "sha3/std"]
+std = ["evm-core/std"]


### PR DESCRIPTION
## Summary
The \`sha3\` crate has been declared in both \`Cargo.toml\` and \`runtime/Cargo.toml\` since the upstream SputnikVM fork, but is **not actually used**:
- The SHA3 opcode handler in \`runtime/src/eval/system.rs\` delegates to \`Handler::keccak256_h256()\`, not \`sha3::Keccak256\` (the original \`Keccak256::digest\` calls were commented out at the time of the Rome fork).
- \`lib.rs\` does not re-export \`sha3\`.
- Grepping \`rome-evm-private\` / \`rome-sdk\` / \`rome-apps\` confirms no downstream consumer pulls \`sha3\` through this crate.

## Why this PR (vs dependabot #24)
Dependabot #24 tries to bump \`sha3 0.8 → 0.11\`. That fails CI because \`sha3 0.10+\` removed the \`std\` feature flag that both \`Cargo.toml\` files reference under their own \`std\` feature. Rather than reproduce a dead dep with a different version pin, this PR removes it.

## Test plan
- [x] \`RUSTFLAGS=-Aunexpected_cfgs cargo build --release\` — succeeds
- [x] \`RUSTFLAGS=-Aunexpected_cfgs cargo clippy\` — clean
- [x] \`RUSTFLAGS=-Aunexpected_cfgs cargo test\` — 0 tests (none defined in this repo)
- [x] Verified zero \`use sha3 / sha3:: / sha3 = \` references in rome-evm-private, rome-sdk, rome-apps — no downstream rebuild needed

🤖 _This response was generated by Claude Code._