### PR TITLE
fix(vm): bound Config.memory_limit to close off-chain emulation OOM

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,7 +232,10 @@ impl Config {
 			create_increase_nonce: true,
 			call_l64_after_gas: true,
 			stack_limit: 1024,
-			memory_limit: usize::max_value(),
+			// Finite bound so off-chain emulation can't be driven to a host OOM by a
+			// single memory op at a huge offset (the Vec::resize in Memory::set). 64 MiB
+			// is far above any gas-affordable EVM memory; on-chain the SBF heap binds first.
+			memory_limit: 64 * 1024 * 1024,
 			call_stack_limit: 1024,
 			create_contract_limit: Some(0x6000),
 			call_stipend: 2300,

--- a/tests/memory_limit.rs
+++ b/tests/memory_limit.rs
@@ -1,0 +1,30 @@
+//! DoS guard: the interpreter's `Config.memory_limit` bounds the backing
+//! `Vec::resize` in `Memory::set`. With `usize::MAX` (the prior default) a
+//! single MSTORE/CALLDATACOPY/MCOPY at a huge offset resizes unbounded → host
+//! OOM in native (off-chain) emulation, which the proxy's `catch_unwind` cannot
+//! contain (an allocator abort is not an unwind). The default must be finite.
+//! Run: `RUSTFLAGS=-Aunexpected_cfgs cargo test`.
+
+use evm::{Memory, ExitFatal, CONFIG};
+
+// Compile-time invariant: the emulation memory limit is finite and sane — never
+// `usize::MAX`. A regression to an unbounded default fails to compile here.
+const _: () = assert!(
+    CONFIG.memory_limit > 0 && CONFIG.memory_limit <= 256 * 1024 * 1024,
+    "CONFIG.memory_limit must be finite and bounded (<= 256 MiB)",
+);
+
+#[test]
+fn set_past_memory_limit_fails_closed() {
+    // With the limit armed (bounded by the const assert above, so `+ 32` cannot
+    // overflow), a write past it returns NotSupported rather than attempting an
+    // unbounded allocation. `Memory::new` pre-reserves 1 KiB and the guard
+    // rejects before `resize`, so this allocates nothing.
+    let mut mem = Memory::new(CONFIG.memory_limit);
+    let past = CONFIG.memory_limit + 32;
+    assert_eq!(
+        mem.set(past, &[0u8; 32], Some(32)),
+        Err(ExitFatal::NotSupported),
+        "set() past memory_limit must fail closed",
+    );
+}


### PR DESCRIPTION
## What
Arm `Config.memory_limit` (was `usize::max_value()` → 64 MiB) so the existing `Memory::set` bound is actually enforced.

## Why
On the stateless off-chain execution path (read-only calls / gas estimation) the interpreter runs natively in-process with no gas metering — this fork has no gasometer. A single `MSTORE` / `CALLDATACOPY` / `MCOPY` at a huge offset drives `data.resize(multi-GB)` in `core/src/memory.rs`; the `pos > self.limit` guard never fires while the limit is `usize::MAX`, so the allocation proceeds → host OOM / allocator abort, which an unwind boundary cannot catch. One crafted read request can take the process down.

Memory gas is quadratic, so 64 MiB is far above any gas-affordable EVM memory (billions of gas) — behaviour is unchanged for real transactions, and execution hosts bind well below this via their runtime heap. The `Memory::set` comparison already runs on every write, so this is a pure constant change with **zero added cost**.

## Test
- Compile-time invariant: the default limit is finite and ≤ 256 MiB (a regression to an unbounded default fails to compile).
- Runtime: `Memory::set` past the limit returns `ExitFatal::NotSupported` (fail-closed) instead of allocating.
- Adjacent `core/tests/load_h256.rs` green; `cargo clippy` clean.

## Context
Root of a coordinated set of off-chain-emulation bounds; merged first so downstream consumers pick it up on rebuild. Downstream CI is expected red until this lands and pins update.