### PR TITLE
Update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Key changes from upstream SputnikVM:
 - Removed unused backend/gasometer crates (PR #11)
 - Dropped unused `sha3` dep (PR #25) — SHA3 opcode goes through `Handler::keccak256_h256`
 - Per-opcode allocation overhead eliminated (PR #29) — `Stack::new` pre-reserves 64 slots, `Memory::new` pre-reserves 1 KiB, and `Memory::load_h256(offset)` reads a 32-byte word directly into an `H256` (no per-MLOAD `vec![0; 32]` heap alloc). Behaviour-preserving — `load_h256` is bit-identical to the prior `H256::from_slice(&get(offset, 32))` (verified by the differential test at `core/tests/load_h256.rs`); the two `with_capacity` hints are capacity-only and the Borsh-serialized form is byte-identical. Measured on a Uniswap V3 single-hop swap in the Solana SVM: −33,808 compute units (−2.54%), −23,552 peak heap (−14.5%), bit-identical output.
+- `Config.memory_limit` bounded at 64 MiB (PR #31) — previously `usize::MAX`, which let a single MSTORE/CALLDATACOPY/MCOPY at a huge offset drive `Memory::set`'s `Vec::resize` unbounded and OOM the host in native off-chain emulation (the proxy's `catch_unwind` cannot contain an allocator abort). 64 MiB is far above any gas-affordable EVM memory; on-chain the SBF heap binds first, so behaviour is unchanged for real txs. A compile-time `const _: () = assert!(...)` in `core/tests/memory_limit.rs` fails the build if the default ever regresses to unbounded, plus a runtime `set_past_memory_limit_fails_closed` test asserts `ExitFatal::NotSupported` on writes past the limit.
 
 ## Dependency Management
 
@@ -87,7 +88,7 @@ Key changes from upstream SputnikVM:
 - After any change, run `cargo test` here, then verify `rome-evm-private` builds against the local checkout (`../evm` path dependency).
 - The SELFDESTRUCT opcode is disabled — do not re-enable.
 - Handler trait modifications affect all EVM execution paths.
-- One integration test lives here (`core/tests/load_h256.rs`, the MLOAD differential added in PR #29); broad opcode coverage still lives in `rome-evm-private/tests/`.
+- Two integration tests live here: `core/tests/load_h256.rs` (MLOAD differential added in PR #29) and `tests/memory_limit.rs` (memory-limit fail-closed guard added in PR #31, with a compile-time `const _: () = assert!(CONFIG.memory_limit <= 256 * 1024 * 1024)` invariant). Broad opcode coverage still lives in `rome-evm-private/tests/`.
 
 ## Change Impact Map
 


### PR DESCRIPTION
Weekly automated update of CLAUDE.md to reflect current codebase state.

- Add PR #31 note: `Config.memory_limit` bounded at 64 MiB to close off-chain emulation OOM. The prior `usize::MAX` default let a single MSTORE/CALLDATACOPY/MCOPY at a huge offset drive `Memory::set`'s `Vec::resize` unbounded; native off-chain emulation OOMed uncatchably (allocator abort is not an unwind).
- Add the new `tests/memory_limit.rs` integration test to the Agent Execution Guide (paired with the existing `core/tests/load_h256.rs`) plus its compile-time `const _: () = assert!(...)` invariant that fails the build if the default ever regresses.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nJpWRfK4gyQGCiGdnXSAG)_