### PR TITLE
docs: Rome-context line atop the upstream README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is . For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
+
 # SputnikVM: Rust Ethereum Virtual Machine Implementation
 
 [![Build Status](https://travis-ci.org/sorpaas/rust-evm.svg?branch=master)](https://travis-ci.org/sorpaas/rust-evm)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is . For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
+> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is the Rust EVM interpreter (SputnikVM) at the core of Rome's EVM execution. For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
 
 # SputnikVM: Rust Ethereum Virtual Machine Implementation
 


### PR DESCRIPTION
Fleet-audit fix: this fork's README was pure upstream with zero Rome context. Adds one line at the top saying what the fork is for in Rome's stack + links to the org and docs. No other changes.